### PR TITLE
Fixed a compatibility problem with a new scikit-learn (v. 0.18) becau…

### DIFF
--- a/clf/utils/_mf.py
+++ b/clf/utils/_mf.py
@@ -23,7 +23,7 @@ def _mf(x, Id, grp, self, display, probOccur):
     for k, i in enumerate(cvOut):
 
         predCv, yTestCv = [], []
-        for train_index, test_index in i:
+        for train_index, test_index in i.split(x,y):
 
             # Get training and testing sets:
             xTrain, xTest, yTrain, yTest = x[train_index, :], x[


### PR DESCRIPTION
Fix for the incompatibility issue with scikit-learn v. 0.18

Due to the changed behaviour of StratifiedKFold multifeature classification failed to run. 
In the new version of scikit StratifiedKFold doesn't return iterable anymore. In order to get the split one should use StratifiedKFold.split(X,y) now 